### PR TITLE
Migrate existing BTC checks from clang-3.0 (BTCCABCOM-3151)

### DIFF
--- a/clang-tidy/btc/BtcTidyModule.cpp
+++ b/clang-tidy/btc/BtcTidyModule.cpp
@@ -11,6 +11,12 @@
 #include "../ClangTidyModule.h"
 #include "../ClangTidyModuleRegistry.h"
 #include "UnmanagedDerivedFromSharableCheck.h"
+#include "CallingSfehlerWithStopOnErrorCheck.h"
+#include "GlobalVariablesCheck.h"
+#include "MultipleParametersOfSameTypeCheck.h"
+#include "NoAssignmentToReferenceParameterCheck.h"
+#include "OptionalParameterInVirtualMethodCheck.h"
+#include "SingletonCheck.h"
 
 using namespace clang::ast_matchers;
 
@@ -24,6 +30,18 @@ public:
   void addCheckFactories(ClangTidyCheckFactories &CheckFactories) override {
     CheckFactories.registerCheck<UnmanagedDerivedFromSharableCheck>(
         "btc-unmanaged-derived-from-sharable");
+    CheckFactories.registerCheck<CallingSfehlerWithStopOnErrorCheck>(
+        "btc-calling-SFehler-with-stop-on-error");
+    CheckFactories.registerCheck<GlobalVariablesCheck>(
+        "btc-global-variables");
+    CheckFactories.registerCheck<MultipleParametersOfSameTypeCheck>(
+        "btc-multiple-parameters-of-same-type");
+    CheckFactories.registerCheck<NoAssignmentToReferenceParameterCheck>(
+        "btc-no-assignment-to-reference-parameter");
+    CheckFactories.registerCheck<OptionalParameterInVirtualMethodCheck>(
+        "btc-optional-parameter-in-virtual-method");
+    CheckFactories.registerCheck<SingletonCheck>(
+        "btc-singleton");
   }
 };
 

--- a/clang-tidy/btc/CMakeLists.txt
+++ b/clang-tidy/btc/CMakeLists.txt
@@ -3,6 +3,12 @@ set(LLVM_LINK_COMPONENTS support)
 add_clang_library(clangTidyBtcModule
   BtcTidyModule.cpp
   UnmanagedDerivedFromSharableCheck.cpp
+  CallingSfehlerWithStopOnErrorCheck.cpp
+  GlobalVariablesCheck.cpp
+  MultipleParametersOfSameTypeCheck.cpp
+  NoAssignmentToReferenceParameterCheck.cpp
+  OptionalParameterInVirtualMethodCheck.cpp
+  SingletonCheck.cpp
 
   LINK_LIBS
   clangAST

--- a/clang-tidy/btc/CallingSfehlerWithStopOnErrorCheck.cpp
+++ b/clang-tidy/btc/CallingSfehlerWithStopOnErrorCheck.cpp
@@ -1,0 +1,39 @@
+//===--- CallingSfehlerWithStopOnErrorCheck.cpp - clang-tidy---------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "CallingSfehlerWithStopOnErrorCheck.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+
+using namespace clang::ast_matchers;
+
+namespace clang {
+namespace tidy {
+namespace btc {
+
+void CallingSfehlerWithStopOnErrorCheck::registerMatchers(MatchFinder *Finder) {
+  Finder->addMatcher(
+      callExpr(callee(functionDecl(hasName("SFehler"), parameterCountIs(6))))
+          .bind("SFehler"),
+      this);
+}
+
+void CallingSfehlerWithStopOnErrorCheck::check(const MatchFinder::MatchResult &Result) {
+  const auto *MatchedCallExpr = Result.Nodes.getNodeAs<CallExpr>("SFehler");
+  const Expr *errorResult = MatchedCallExpr->getArg(5);
+  llvm::APSInt errorResultValue;
+  if (errorResult->EvaluateAsInt(errorResultValue, *Result.Context))
+   if (errorResultValue == 1)
+      diag(MatchedCallExpr->getLocStart(),
+           "SFehler function called with STOPONERROR parameter.");
+}
+
+}  // namespace btc
+}  // namespace tidy
+}  // namespace clang

--- a/clang-tidy/btc/CallingSfehlerWithStopOnErrorCheck.h
+++ b/clang-tidy/btc/CallingSfehlerWithStopOnErrorCheck.h
@@ -1,0 +1,35 @@
+//===--- CallingSfehlerWithStopOnErrorCheck.h - clang-tidy-------*- C++ -*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_BTC_CALLINGSFEHLERWITHSTOPONERRORCHECK_H
+#define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_BTC_CALLINGSFEHLERWITHSTOPONERRORCHECK_H
+
+#include "../ClangTidy.h"
+
+namespace clang {
+namespace tidy {
+namespace btc {
+
+/// Finds function SFehler calls with STOPONERROR as parameter.
+///
+/// For the user-facing documentation see:
+/// http://clang.llvm.org/extra/clang-tidy/checks/btc-calling-SFehler-with-stop-on-error.html
+class CallingSfehlerWithStopOnErrorCheck : public ClangTidyCheck {
+ public:
+  CallingSfehlerWithStopOnErrorCheck(StringRef Name, ClangTidyContext *Context)
+      : ClangTidyCheck(Name, Context) {}
+  void registerMatchers(ast_matchers::MatchFinder *Finder) override;
+  void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
+};
+
+}  // namespace btc
+}  // namespace tidy
+}  // namespace clang
+
+#endif  // LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_BTC_CALLINGSFEHLERWITHSTOPONERRORCHECK_H

--- a/clang-tidy/btc/GlobalVariablesCheck.cpp
+++ b/clang-tidy/btc/GlobalVariablesCheck.cpp
@@ -1,0 +1,39 @@
+//===--- GlobalVariablesCheck.cpp - clang-tidy-----------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "GlobalVariablesCheck.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+
+using namespace clang::ast_matchers;
+
+namespace clang {
+namespace tidy {
+namespace btc {
+
+void GlobalVariablesCheck::registerMatchers(MatchFinder *Finder) {
+  Finder->addMatcher(varDecl(hasGlobalStorage()).bind("Var"), this);
+}
+
+void GlobalVariablesCheck::check(const MatchFinder::MatchResult &Result) {
+  const auto *MatchedVarDecl = Result.Nodes.getNodeAs<VarDecl>("Var");
+  if (MatchedVarDecl->getAccess() == AS_none ||
+      MatchedVarDecl->getAccess() == AS_public) {
+    // It is not part of a class or is a public static field.
+    if (!MatchedVarDecl->isStaticLocal()) {
+      // and it is not a static local variable.
+      // At this point I hope it must be a global variable.
+      diag(MatchedVarDecl->getLocStart(), "Global variable detected.");
+    }
+  }
+}
+
+}  // namespace btc
+}  // namespace tidy
+}  // namespace clang

--- a/clang-tidy/btc/GlobalVariablesCheck.h
+++ b/clang-tidy/btc/GlobalVariablesCheck.h
@@ -1,0 +1,36 @@
+//===--- GlobalVariablesCheck.h - clang-tidy---------------------*- C++ -*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_BTC_GLOBALVARIABLESCHECK_H
+#define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_BTC_GLOBALVARIABLESCHECK_H
+
+#include "../ClangTidy.h"
+
+namespace clang {
+namespace tidy {
+namespace btc {
+
+/// This Check is intended to detect the places in code
+/// where global variables are declared
+///
+/// For the user-facing documentation see:
+/// http://clang.llvm.org/extra/clang-tidy/checks/btc-global-variables.html
+class GlobalVariablesCheck : public ClangTidyCheck {
+ public:
+  GlobalVariablesCheck(StringRef Name, ClangTidyContext *Context)
+      : ClangTidyCheck(Name, Context) {}
+  void registerMatchers(ast_matchers::MatchFinder *Finder) override;
+  void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
+};
+
+}  // namespace btc
+}  // namespace tidy
+}  // namespace clang
+
+#endif  // LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_BTC_GLOBALVARIABLESCHECK_H

--- a/clang-tidy/btc/MultipleParametersOfSameTypeCheck.cpp
+++ b/clang-tidy/btc/MultipleParametersOfSameTypeCheck.cpp
@@ -1,0 +1,58 @@
+//===--- MultipleParametersOfSameTypeCheck.cpp - clang-tidy----------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "MultipleParametersOfSameTypeCheck.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+
+using namespace clang::ast_matchers;
+
+namespace clang {
+namespace tidy {
+namespace btc {
+
+void MultipleParametersOfSameTypeCheck::registerMatchers(MatchFinder *Finder) {
+  Finder->addMatcher(functionDecl().bind("func"), this);
+}
+
+void MultipleParametersOfSameTypeCheck::check(
+    const MatchFinder::MatchResult &Result) {
+  const auto *MatchedDecl = Result.Nodes.getNodeAs<FunctionDecl>("func");
+  std::unordered_map<std::string, std::set<const ParmVarDecl *> > typeMap;
+  for (unsigned int i = 0; i < MatchedDecl->getNumParams(); ++i) {
+    const auto *paramDecl = MatchedDecl->getParamDecl(i);
+    typeMap[paramDecl->getType().getCanonicalType().getAsString()].insert(
+        paramDecl);
+  }
+  bool firstDiag = true;
+
+  for (auto &&entry : typeMap) {
+    if (entry.second.size() > 1) {
+      if (firstDiag) {
+        diag(MatchedDecl->getLocation(),
+             "function '%0' has multiple parameters of same type")
+            << MatchedDecl->getNameAsString();
+        firstDiag = false;
+      }
+      for (auto &&param : entry.second) {
+        if (param->getDeclName().isEmpty())
+          continue; /** \todo output index in this case! */
+
+        diag(param->getLocation(),
+             "parameter '%0' with type '%1' (total number of parameters with "
+             "this type: %2)")
+            << param->getNameAsString() << param->getType()
+            << (unsigned int)entry.second.size();
+      }
+    }
+  }
+}
+}  // namespace btc
+}  // namespace tidy
+}  // namespace clang

--- a/clang-tidy/btc/MultipleParametersOfSameTypeCheck.h
+++ b/clang-tidy/btc/MultipleParametersOfSameTypeCheck.h
@@ -1,0 +1,36 @@
+//===--- MultipleParametersOfSameTypeCheck.h - clang-tidy--------*- C++ -*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_BTC_MULTIPLEPARAMETERSOFSAMETYPECHECK_H
+#define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_BTC_MULTIPLEPARAMETERSOFSAMETYPECHECK_H
+
+#include "../ClangTidy.h"
+
+namespace clang {
+namespace tidy {
+namespace btc {
+
+/// This check targets function declarations with multiple parameters of the
+/// same type
+///
+/// For the user-facing documentation see:
+/// http://clang.llvm.org/extra/clang-tidy/checks/btc-multiple-parameters-of-same-type.html
+class MultipleParametersOfSameTypeCheck : public ClangTidyCheck {
+ public:
+  MultipleParametersOfSameTypeCheck(StringRef Name, ClangTidyContext *Context)
+      : ClangTidyCheck(Name, Context) {}
+  void registerMatchers(ast_matchers::MatchFinder *Finder) override;
+  void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
+};
+
+}  // namespace btc
+}  // namespace tidy
+}  // namespace clang
+
+#endif  // LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_BTC_MULTIPLEPARAMETERSOFSAMETYPECHECK_H

--- a/clang-tidy/btc/NoAssignmentToReferenceParameterCheck.cpp
+++ b/clang-tidy/btc/NoAssignmentToReferenceParameterCheck.cpp
@@ -1,0 +1,40 @@
+//===--- NoAssignmentToReferenceParameterCheck.cpp - clang-tidy------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "NoAssignmentToReferenceParameterCheck.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+
+using namespace clang::ast_matchers;
+
+namespace clang {
+namespace tidy {
+namespace btc {
+
+void NoAssignmentToReferenceParameterCheck::registerMatchers(
+    MatchFinder *Finder) {
+  Finder->addMatcher(binaryOperator(hasOperatorName("="),
+                                    hasLHS(declRefExpr().bind("declref"))),
+                     this);
+}
+void NoAssignmentToReferenceParameterCheck::check(
+    const MatchFinder::MatchResult &Result) {
+  const auto *MatchedDeclRef = Result.Nodes.getNodeAs<DeclRefExpr>("declref");
+  const auto *decl = llvm::dyn_cast_or_null<const clang::ParmVarDecl>(
+      MatchedDeclRef->getDecl());
+  if (decl && decl->getType().getTypePtr()->isReferenceType()) {
+    diag(MatchedDeclRef->getLocation(),
+         "reference parameter %0 must not be assigned to parameter declared "
+         "above with type %1")
+        << decl->getName() << decl->getType();
+  }
+}
+}  // namespace btc
+}  // namespace tidy
+}  // namespace clang

--- a/clang-tidy/btc/NoAssignmentToReferenceParameterCheck.h
+++ b/clang-tidy/btc/NoAssignmentToReferenceParameterCheck.h
@@ -1,0 +1,37 @@
+//===--- NoAssignmentToReferenceParameterCheck.h - clang-tidy----*- C++ -*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_BTC_NOASSIGNMENTTOREFERENCEPARAMETERCHECK_H
+#define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_BTC_NOASSIGNMENTTOREFERENCEPARAMETERCHECK_H
+
+#include "../ClangTidy.h"
+
+namespace clang {
+namespace tidy {
+namespace btc {
+
+/// For working example see btc-no-assignment-to-reference-parameter.cpp in test
+/// folder.
+///
+/// For the user-facing documentation see:
+/// http://clang.llvm.org/extra/clang-tidy/checks/btc-no-assignment-to-reference-parameter.html
+class NoAssignmentToReferenceParameterCheck : public ClangTidyCheck {
+ public:
+  NoAssignmentToReferenceParameterCheck(StringRef Name,
+                                        ClangTidyContext *Context)
+      : ClangTidyCheck(Name, Context) {}
+  void registerMatchers(ast_matchers::MatchFinder *Finder) override;
+  void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
+};
+
+}  // namespace btc
+}  // namespace tidy
+}  // namespace clang
+
+#endif  // LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_BTC_NOASSIGNMENTTOREFERENCEPARAMETERCHECK_H

--- a/clang-tidy/btc/OptionalParameterInVirtualMethodCheck.cpp
+++ b/clang-tidy/btc/OptionalParameterInVirtualMethodCheck.cpp
@@ -1,0 +1,44 @@
+//===--- OptionalParameterInVirtualMethodCheck.cpp - clang-tidy------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "OptionalParameterInVirtualMethodCheck.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+
+using namespace clang::ast_matchers;
+
+namespace clang {
+namespace tidy {
+namespace btc {
+
+void OptionalParameterInVirtualMethodCheck::registerMatchers(
+    MatchFinder *Finder) {
+  Finder->addMatcher(
+      parmVarDecl(hasDeclContext(cxxMethodDecl(isVirtual()))).bind("param"),
+      this);
+}
+
+void OptionalParameterInVirtualMethodCheck::check(
+    const MatchFinder::MatchResult &Result) {
+  const auto *MatchedDecl = Result.Nodes.getNodeAs<ParmVarDecl>("param");
+  if (!MatchedDecl->hasDefaultArg() ||
+      MatchedDecl
+          ->hasUninstantiatedDefaultArg())  // Fot templates template<class...T>
+                                            // void h(int i = 0, T... args);
+    return;
+  const auto *MatchedFunc =
+      llvm::dyn_cast_or_null<const FunctionDecl>(MatchedDecl->getDeclContext());
+  diag(MatchedDecl->getDefaultArg()->getExprLoc(),
+       "parameter '%0' of virtual function '%1' is optional")
+      << MatchedDecl->getName() << MatchedFunc->getName();
+}
+
+}  // namespace btc
+}  // namespace tidy
+}  // namespace clang

--- a/clang-tidy/btc/OptionalParameterInVirtualMethodCheck.h
+++ b/clang-tidy/btc/OptionalParameterInVirtualMethodCheck.h
@@ -1,0 +1,36 @@
+//===--- OptionalParameterInVirtualMethodCheck.h - clang-tidy----*- C++ -*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_BTC_OPTIONALPARAMETERINVIRTUALMETHODCHECK_H
+#define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_BTC_OPTIONALPARAMETERINVIRTUALMETHODCHECK_H
+
+#include "../ClangTidy.h"
+
+namespace clang {
+namespace tidy {
+namespace btc {
+
+/// Searches for default parameters in virtual functions.
+/// For example of use see btc-optional-parameter-in-virtual-method.cpp in test
+/// folder. For the user-facing documentation see:
+/// http://clang.llvm.org/extra/clang-tidy/checks/btc-optional-parameter-in-virtual-method.html
+class OptionalParameterInVirtualMethodCheck : public ClangTidyCheck {
+ public:
+  OptionalParameterInVirtualMethodCheck(StringRef Name,
+                                        ClangTidyContext *Context)
+      : ClangTidyCheck(Name, Context) {}
+  void registerMatchers(ast_matchers::MatchFinder *Finder) override;
+  void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
+};
+
+}  // namespace btc
+}  // namespace tidy
+}  // namespace clang
+
+#endif  // LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_BTC_OPTIONALPARAMETERINVIRTUALMETHODCHECK_H

--- a/clang-tidy/btc/SingletonCheck.cpp
+++ b/clang-tidy/btc/SingletonCheck.cpp
@@ -1,0 +1,32 @@
+//===--- SingletonCheck.cpp - clang-tidy-----------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "SingletonCheck.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+
+using namespace clang::ast_matchers;
+
+namespace clang {
+namespace tidy {
+namespace btc {
+
+void SingletonCheck::registerMatchers(MatchFinder *Finder) {
+  Finder->addMatcher(
+      cxxRecordDecl(isDerivedFrom("Singleton")).bind("Singleton"), this);
+}
+
+void SingletonCheck::check(const MatchFinder::MatchResult &Result) {
+  const auto *MatchedStmt = Result.Nodes.getNodeAs<CXXRecordDecl>("Singleton");
+  diag(MatchedStmt->getLocStart(), "Use of singleton detected.");
+}
+
+}  // namespace btc
+}  // namespace tidy
+}  // namespace clang

--- a/clang-tidy/btc/SingletonCheck.h
+++ b/clang-tidy/btc/SingletonCheck.h
@@ -1,0 +1,35 @@
+//===--- SingletonCheck.h - clang-tidy---------------------------*- C++ -*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_BTC_SINGLETONCHECK_H
+#define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_BTC_SINGLETONCHECK_H
+
+#include "../ClangTidy.h"
+
+namespace clang {
+namespace tidy {
+namespace btc {
+
+/// This test searches for uses of Singleton pattern.
+///
+/// For the user-facing documentation see:
+/// http://clang.llvm.org/extra/clang-tidy/checks/btc-singleton.html
+class SingletonCheck : public ClangTidyCheck {
+ public:
+  SingletonCheck(StringRef Name, ClangTidyContext *Context)
+      : ClangTidyCheck(Name, Context) {}
+  void registerMatchers(ast_matchers::MatchFinder *Finder) override;
+  void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
+};
+
+}  // namespace btc
+}  // namespace tidy
+}  // namespace clang
+
+#endif  // LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_BTC_SINGLETONCHECK_H

--- a/docs/ReleaseNotes.rst
+++ b/docs/ReleaseNotes.rst
@@ -44,6 +44,36 @@ Major New Features
 
 ...
 
+- New :doc:`btc-singleton
+  <clang-tidy/checks/btc-singleton>` check
+
+  Find Singletons.
+
+- New :doc:`btc-calling-SFehler-with-stop-on-error
+  <clang-tidy/checks/btc-calling-SFehler-with-stop-on-error>` check
+
+  Find SFeler calls with 6th parameter set on STOP_ON_ERROR
+
+- New :doc:`btc-optional-parameter-in-virtual-method
+  <clang-tidy/checks/btc-optional-parameter-in-virtual-method>` check
+
+  Virtual methods should not have optional patameters.
+
+- New :doc:`btc-no-assignment-to-reference-parameter
+  <clang-tidy/checks/btc-no-assignment-to-reference-parameter>` check
+
+  Assiments to reference parameters are prohibited.
+
+- New :doc:`btc-multiple-parameters-of-same-type
+  <clang-tidy/checks/btc-multiple-parameters-of-same-type>` check
+
+  Find multiple parameters of the same type.
+
+- New :doc:`btc-global-variables
+  <clang-tidy/checks/btc-global-variables>` check
+
+  Find global variables.
+
 Improvements to clang-query
 ---------------------------
 

--- a/docs/clang-tidy/checks/btc-calling-SFehler-with-stop-on-error.rst
+++ b/docs/clang-tidy/checks/btc-calling-SFehler-with-stop-on-error.rst
@@ -1,0 +1,6 @@
+.. title:: clang-tidy - btc-calling-SFehler-with-stop-on-error
+
+btc-calling-SFehler-with-stop-on-error
+======================================
+
+FIXME: Describe what patterns does the check detect and why. Give examples.

--- a/docs/clang-tidy/checks/btc-global-variables.rst
+++ b/docs/clang-tidy/checks/btc-global-variables.rst
@@ -1,0 +1,6 @@
+.. title:: clang-tidy - btc-global-variables
+
+btc-global-variables
+====================
+
+FIXME: Describe what patterns does the check detect and why. Give examples.

--- a/docs/clang-tidy/checks/btc-multiple-parameters-of-same-type.rst
+++ b/docs/clang-tidy/checks/btc-multiple-parameters-of-same-type.rst
@@ -1,0 +1,6 @@
+.. title:: clang-tidy - btc-multiple-parameters-of-same-type
+
+btc-multiple-parameters-of-same-type
+====================================
+
+FIXME: Describe what patterns does the check detect and why. Give examples.

--- a/docs/clang-tidy/checks/btc-no-assignment-to-reference-parameter.rst
+++ b/docs/clang-tidy/checks/btc-no-assignment-to-reference-parameter.rst
@@ -1,0 +1,6 @@
+.. title:: clang-tidy - btc-no-assignment-to-reference-parameter
+
+btc-no-assignment-to-reference-parameter
+========================================
+
+FIXME: Describe what patterns does the check detect and why. Give examples.

--- a/docs/clang-tidy/checks/btc-optional-parameter-in-virtual-method.rst
+++ b/docs/clang-tidy/checks/btc-optional-parameter-in-virtual-method.rst
@@ -1,0 +1,8 @@
+..title::clang - tidy - btc - optional - parameter - in - virtual -
+        method
+
+            btc -
+        optional - parameter - in - virtual - method ==
+    == == == == == == == == == == == == == == == == == == ==
+
+    FIXME : Describe what patterns does the check detect and why.Give examples.

--- a/docs/clang-tidy/checks/btc-singleton.rst
+++ b/docs/clang-tidy/checks/btc-singleton.rst
@@ -1,0 +1,6 @@
+.. title:: clang-tidy - btc-singleton
+
+btc-singleton
+=============
+
+FIXME: Describe what patterns does the check detect and why. Give examples.

--- a/docs/clang-tidy/checks/list.rst
+++ b/docs/clang-tidy/checks/list.rst
@@ -20,6 +20,13 @@ Clang-Tidy Checks
    android-comparison-in-temp-failure-retry
    boost-use-to-string
    btc-unmanaged-derived-from-sharable
+   btc-Singleton
+   btc-calling-SFehler-with-stop-on-error
+   btc-global-variables
+   btc-multiple-parameters-of-same-type
+   btc-no-assignment-to-reference-parameter
+   btc-optional-parameter-in-virtual-method
+   btc-singleton
    bugprone-argument-comment
    bugprone-assert-side-effect
    bugprone-bool-pointer-implicit-conversion

--- a/test/clang-tidy/btc-calling-SFehler-with-stop-on-error.cpp
+++ b/test/clang-tidy/btc-calling-SFehler-with-stop-on-error.cpp
@@ -1,0 +1,12 @@
+// RUN: %check_clang_tidy %s btc-calling-SFehler-with-stop-on-error %t
+int SFehler(int a, int b, int c, int d, int e) { return a + b; }
+int SFehler(int a, int b, int c, int d, int e, int f) { return b * b; }
+int SFehler(int a, int b, int c, float d, float e, float f) { return a + c; }
+void f() {
+  auto R = SFehler(9, 9, 9, 9, 9, 1);
+  // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: SFehler function called with
+  // STOPONERROR parameter. [btc-calling-SFehler-with-stop-on-error]
+  R = SFehler(9, 9, 9, 9, 9, 9);
+  R = SFehler(9, 9, 9, 9, 1);
+  SFehler(2, 2, 2, 2.0f, 1.0f, 2.0f);
+}

--- a/test/clang-tidy/btc-global-variables.cpp
+++ b/test/clang-tidy/btc-global-variables.cpp
@@ -1,0 +1,23 @@
+// RUN: %check_clang_tidy %s btc-global-variables %t
+
+int globalInt = 1;
+// CHECK-MESSAGES: :[[@LINE-1]]:1: warning: Global variable detected.
+// [btc-global-variables]
+
+class Object {
+ public:
+  Object();
+  int do_Object() { return 1; }
+  int field = 1;
+  // Should not trigger
+ private:
+  static int static_field;
+};
+
+int Object::static_field = 0;
+// Should not trigger
+
+void f() {
+  static int staticLocalVariable = 2;
+  // Should not trigger
+}

--- a/test/clang-tidy/btc-multiple-parameters-of-same-type.cpp
+++ b/test/clang-tidy/btc-multiple-parameters-of-same-type.cpp
@@ -1,0 +1,13 @@
+// RUN: %check_clang_tidy %s btc-multiple-parameters-of-same-type %t
+
+void f(int y, int z);
+// CHECK-MESSAGES: :[[@LINE-1]]:6: warning: function 'f' has multiple parameters
+// of same type [btc-multiple-parameters-of-same-type]
+// CHECK-MESSAGES: :[[@LINE-3]]:12: warning: parameter 'y' with type ''int''
+// (total number of parameters with this type: 2)
+// [btc-multiple-parameters-of-same-type]
+// CHECK-MESSAGES: :[[@LINE-6]]:19: warning: parameter 'z' with type ''int''
+// (total number of parameters with this type: 2)
+// [btc-multiple-parameters-of-same-type]
+
+void awesome_f2(int i, double d, float u);

--- a/test/clang-tidy/btc-no-assignment-to-reference-parameter.cpp
+++ b/test/clang-tidy/btc-no-assignment-to-reference-parameter.cpp
@@ -1,0 +1,10 @@
+// RUN: %check_clang_tidy %s btc-no-assignment-to-reference-parameter %t
+int y = 1;
+void function(int &x) {
+  if (x = 2)
+    // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: reference parameter x must not
+    // be assigned to parameter declared above with type 'int &'
+    // [btc-no-assignment-to-reference-parameter]
+    x += 1;
+}
+void Xmain() { function(y); }

--- a/test/clang-tidy/btc-optional-parameter-in-virtual-method.cpp
+++ b/test/clang-tidy/btc-optional-parameter-in-virtual-method.cpp
@@ -1,0 +1,20 @@
+// RUN: %check_clang_tidy %s btc-optional-parameter-in-virtual-method %t
+
+class P {
+ public:
+  virtual void f(int x = 17);  // f has an unparsed default argument now
+  // CHECK-MESSAGES: :[[@LINE-1]]:26: warning: parameter 'x' of virtual function
+  // 'f' is optional [btc-optional-parameter-in-virtual-method]
+  virtual void g();
+  void h();
+};  // f has a regular default argument now
+
+template <class P>
+class C {
+ public:
+  virtual void f(int y = 21);  // f has an uninstantiated default argument
+  // CHECK-MESSAGES: :[[@LINE-1]]:26: warning: parameter 'y' of virtual function
+  // 'f' is optional [btc-optional-parameter-in-virtual-method]
+  virtual void g();
+  void h();
+};

--- a/test/clang-tidy/btc-singleton.cpp
+++ b/test/clang-tidy/btc-singleton.cpp
@@ -1,0 +1,7 @@
+// RUN: %check_clang_tidy %s btc-singleton %t
+class Singleton {};
+class A : Singleton {};
+// CHECK-MESSAGES: :[[@LINE-1]]:1: warning: Use of singleton detected.
+// [btc-singleton]
+
+class C {};


### PR DESCRIPTION
Tests migrated from clang 3.0.