### PR TITLE
cab exception check

### DIFF
--- a/clang-tidy/btc/BtcTidyModule.cpp
+++ b/clang-tidy/btc/BtcTidyModule.cpp
@@ -17,6 +17,7 @@
 #include "NoAssignmentToReferenceParameterCheck.h"
 #include "OptionalParameterInVirtualMethodCheck.h"
 #include "SingletonCheck.h"
+#include "CABExceptionCheck.h"
 
 using namespace clang::ast_matchers;
 
@@ -42,6 +43,8 @@ public:
         "btc-optional-parameter-in-virtual-method");
     CheckFactories.registerCheck<SingletonCheck>(
         "btc-singleton");
+    CheckFactories.registerCheck<btc::CABExceptionCheck>(
+        "btc-use-of-cab-exception");
   }
 };
 

--- a/clang-tidy/btc/CABExceptionCheck.cpp
+++ b/clang-tidy/btc/CABExceptionCheck.cpp
@@ -20,16 +20,16 @@ void CABExceptionCheck::registerMatchers(MatchFinder *Finder) {
       cxxCatchStmt(
           has(varDecl(hasType(pointsTo(cxxRecordDecl(isSameOrDerivedFrom(
               hasName("BTC::Commons::Core::Exception"))))))))
-          .bind("CABException"),
+          .bind(CABExceptionMatch),
       this);
-  Finder->addMatcher(cxxThrowExpr().bind("CxxThrowExpr"), this);
+  Finder->addMatcher(cxxThrowExpr().bind(CxxThrowExprMatch), this);
 }
 
 void CABExceptionCheck::check(const MatchFinder::MatchResult &Result) {
   // catchStmt(has(varDecl(hasType(references(isConstQualified()))))) müsste
   // auch funktionieren
   const auto *MatchedStmt =
-      Result.Nodes.getNodeAs<CXXCatchStmt>("CABException");
+      Result.Nodes.getNodeAs<CXXCatchStmt>(CABExceptionMatch);
   if (MatchedStmt) {
     const auto *ExceptionDecl = MatchedStmt->getExceptionDecl();
     if (ExceptionDecl) { // no catch all
@@ -42,7 +42,7 @@ void CABExceptionCheck::check(const MatchFinder::MatchResult &Result) {
             if (!mExceptionsAsPointers) {
               diag(MatchedStmt->getLocStart(),
                    "cab exception " + CaughtType.getAsString() +
-                       " is catched as a pointer. It must be catched as const "
+                       " is caught as a pointer. It must be caught as const "
                        "reference.",
                    clang::DiagnosticIDs::Warning);
             }
@@ -50,13 +50,13 @@ void CABExceptionCheck::check(const MatchFinder::MatchResult &Result) {
             if (mExceptionsAsPointers) {
               diag(MatchedStmt->getLocStart(),
                    "cab exception " + CaughtType.getAsString() +
-                       " must be catched const qualified.",
+                       " must be caught const qualified.",
                    clang::DiagnosticIDs::Warning);
 
             } else {
               diag(MatchedStmt->getLocStart(),
                    "cab exception " + CaughtType.getAsString() +
-                       " must be catched as const reference.",
+                       " must be caught as const reference.",
                    clang::DiagnosticIDs::Warning);
             }
           }
@@ -65,7 +65,7 @@ void CABExceptionCheck::check(const MatchFinder::MatchResult &Result) {
     }
   } else {
     const auto *CxxThrowExpr =
-        Result.Nodes.getNodeAs<CXXThrowExpr>("CxxThrowExpr");
+        Result.Nodes.getNodeAs<CXXThrowExpr>(CxxThrowExprMatch);
     if (CxxThrowExpr) {
       auto *subExpr = CxxThrowExpr->getSubExpr();
       if (!subExpr)

--- a/clang-tidy/btc/CABExceptionCheck.cpp
+++ b/clang-tidy/btc/CABExceptionCheck.cpp
@@ -1,0 +1,92 @@
+//===--- CABExceptionCheck.cpp - clang-tidy----------------===//
+//    This Check is intended to detect the places in code
+//    where BTC::Commons::Core::Exception  are
+//    wrongly used.
+//===-----------------------------------------------------===//
+
+#include "CABExceptionCheck.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+#include "clang/ASTMatchers/ASTMatchers.h"
+
+using namespace clang::ast_matchers;
+
+namespace clang {
+namespace tidy {
+namespace btc {
+
+void CABExceptionCheck::registerMatchers(MatchFinder *Finder) {
+  Finder->addMatcher(
+      cxxCatchStmt(
+          has(varDecl(hasType(pointsTo(cxxRecordDecl(isSameOrDerivedFrom(
+              hasName("BTC::Commons::Core::Exception"))))))))
+          .bind("CABException"),
+      this);
+  Finder->addMatcher(cxxThrowExpr().bind("CxxThrowExpr"), this);
+}
+
+void CABExceptionCheck::check(const MatchFinder::MatchResult &Result) {
+  // catchStmt(has(varDecl(hasType(references(isConstQualified()))))) müsste
+  // auch funktionieren
+  const auto *MatchedStmt =
+      Result.Nodes.getNodeAs<CXXCatchStmt>("CABException");
+  if (MatchedStmt) {
+    const auto *ExceptionDecl = MatchedStmt->getExceptionDecl();
+    if (ExceptionDecl) { // no catch all
+      const auto CaughtType = MatchedStmt->getCaughtType();
+      const auto *BaseType = CaughtType.getTypePtr();
+      if (BaseType->isPointerType()) {
+        const auto *Decl = BaseType->getPointeeCXXRecordDecl();
+        if (Decl) {
+          if (BaseType->getPointeeType().isConstQualified()) {
+            if (!mExceptionsAsPointers) {
+              diag(MatchedStmt->getLocStart(),
+                   "cab exception " + CaughtType.getAsString() +
+                       " is catched as a pointer. It must be catched as const "
+                       "reference.",
+                   clang::DiagnosticIDs::Warning);
+            }
+          } else {
+            if (mExceptionsAsPointers) {
+              diag(MatchedStmt->getLocStart(),
+                   "cab exception " + CaughtType.getAsString() +
+                       " must be catched const qualified.",
+                   clang::DiagnosticIDs::Warning);
+
+            } else {
+              diag(MatchedStmt->getLocStart(),
+                   "cab exception " + CaughtType.getAsString() +
+                       " must be catched as const reference.",
+                   clang::DiagnosticIDs::Warning);
+            }
+          }
+        }
+      }
+    }
+  } else {
+    const auto *CxxThrowExpr =
+        Result.Nodes.getNodeAs<CXXThrowExpr>("CxxThrowExpr");
+    if (CxxThrowExpr) {
+      auto *subExpr = CxxThrowExpr->getSubExpr();
+      if (!subExpr)
+        return;
+      auto qualType = subExpr->getType();
+      if (qualType->isPointerType()) {
+        // The code is throwing a pointer.
+        if (!mExceptionsAsPointers) {
+          diag(CxxThrowExpr->getLocStart(),
+               "cab exception must be thrown as value",
+               clang::DiagnosticIDs::Warning);
+        }
+      }
+    } 
+  }
+}
+
+void CABExceptionCheck::storeOptions(ClangTidyOptions::OptionMap &Opts) {
+  Options.store(Opts, CABExceptionAsPointerParamName, mExceptionsAsPointers);
+}
+
+} // namespace btc
+} // namespace tidy
+} // namespace clang

--- a/clang-tidy/btc/CABExceptionCheck.h
+++ b/clang-tidy/btc/CABExceptionCheck.h
@@ -28,6 +28,8 @@ public:
   void storeOptions(ClangTidyOptions::OptionMap &Options) override;
 
 private:
+  const std::string CABExceptionMatch = "CABException";
+  const std::string CxxThrowExprMatch = "CxxThrowExpr";
   const bool mExceptionsAsPointers;
 };
 

--- a/clang-tidy/btc/CABExceptionCheck.h
+++ b/clang-tidy/btc/CABExceptionCheck.h
@@ -1,0 +1,36 @@
+#pragma once
+//===--- CABExceptionCheck.h - clangTidyBtcModule----*- C++ -*-===//
+//    This Check is intended to detect the places in code
+//    where BTC::Commons::Core::Exception  are
+//    used.
+//===-------------------------------------------------------===//
+
+#include "../ClangTidy.h"
+//#include "DeclCXX.h"
+
+namespace clang {
+namespace tidy {
+namespace btc {
+
+class CABExceptionCheck : public ClangTidyCheck {
+
+  const std::string CABExceptionAsPointerParamName = "CABExceptionAsPointer";
+
+public:
+  CABExceptionCheck(StringRef Name, ClangTidyContext *Context)
+      : ClangTidyCheck(Name, Context),
+        mExceptionsAsPointers(
+            Options.get(CABExceptionAsPointerParamName, false)) {}
+
+  void registerMatchers(ast_matchers::MatchFinder *Finder) override;
+  void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
+
+  void storeOptions(ClangTidyOptions::OptionMap &Options) override;
+
+private:
+  const bool mExceptionsAsPointers;
+};
+
+} // namespace btc
+} // namespace tidy
+} // namespace clang

--- a/clang-tidy/btc/CMakeLists.txt
+++ b/clang-tidy/btc/CMakeLists.txt
@@ -9,6 +9,7 @@ add_clang_library(clangTidyBtcModule
   NoAssignmentToReferenceParameterCheck.cpp
   OptionalParameterInVirtualMethodCheck.cpp
   SingletonCheck.cpp
+  CABExceptionCheck.cpp
 
   LINK_LIBS
   clangAST


### PR DESCRIPTION
This check looks for wrong usage of cab exceptions. It has a bool parameter btc-use-of-cab-exception.CABExceptionAsPointer to define wanted convention.